### PR TITLE
Fixed cds_length_distribution bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+1. Fixed a bug where `intron_length_distribution` was used instead of `cds_length_distribution` when creating the CDS Length Distribution Graph [#95](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/95)
+
 ### `Dependencies`
 
 1. NextFlow!>=23.04.0

--- a/bin/report_modules/parsers/genometools_gt_stat_parser.py
+++ b/bin/report_modules/parsers/genometools_gt_stat_parser.py
@@ -82,7 +82,7 @@ def parse_genometools_gt_stat_folder(folder_name="genometools_gt_stat"):
         cds_length_distribution_graph = ""
         if cds_length_distribution != []:
             cds_length_distribution_graph = create_dist_graph(
-                intron_length_distribution,
+                cds_length_distribution,
                 "Length",
                 "CDS Length Distribution",
                 f"./{folder_name}/{os.path.basename(report_path)}.cds.length.png",


### PR DESCRIPTION
<!--
# plant-food-research-open/assemblyqc pull request

Many thanks for contributing to plant-food-research-open/assemblyqc!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/plant-food-research-open/assemblyqc/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] Fixed a bug where `intron_length_distribution` was used instead of `cds_length_distribution` when creating the CDS Length Distribution Graph [#95](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/95)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/plant-food-research-open/assemblyqc/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
