### PR TITLE
Reduced the GenomeTools stats figures to 300 DPI and set `synteny_mummer_min_bundle_size` is set to `1000000`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v2.2.0+dev - [30-Sep-2024]
+## v2.2.0+dev - [01-Oct-2024]
 
 ### `Added`
 
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 2. nf-validation@1.1.3
 
 ### `Deprecated`
+
+1. Reduced the GenomeTools stats figures to 300 DPI
+2. Now `synteny_mummer_min_bundle_size` is set to `1000000` by default
 
 ## v2.1.1 - [20-Sep-2024]
 

--- a/bin/report_modules/parsers/genometools_gt_stat_parser.py
+++ b/bin/report_modules/parsers/genometools_gt_stat_parser.py
@@ -335,7 +335,7 @@ def create_dist_graph(groups_dict, x_label, title, file_name):
         arrowprops=dict(color="red", arrowstyle="->, head_width=.15"),
     )
 
-    plt.savefig(file_name, dpi=600)
+    plt.savefig(file_name, dpi=300)
 
     with open(file_name, "rb") as f:
         binary_fc = f.read()

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -85,12 +85,11 @@ A Nextflow pipeline which evaluates assembly quality with multiple QC tools and 
 | `synteny_mummer_plot_type`         | Synteny plot type from Mummer alignments: 'dotplot', 'circos', or 'both'                                                                                                   | `string`  | both    |          |        |
 | `synteny_mummer_m2m_align`         | Include Mummer alignment blocks with many-to-many mappings                                                                                                                 | `boolean` |         |          |        |
 | `synteny_mummer_max_gap`           | Mummer alignments within this distance are bundled together                                                                                                                | `integer` | 1000000 |          |        |
-| `synteny_mummer_min_bundle_size`   | After bundling, any Mummer alignment bundle smaller than this size is filtered out                                                                                         | `integer` | 1000    |          |        |
+| `synteny_mummer_min_bundle_size`   | After bundling, any Mummer alignment bundle smaller than this size is filtered out                                                                                         | `integer` | 1000000 |          |        |
 | `synteny_plot_1_vs_all`            | Create a separate synteny plot for each contig of the target assembly versus all contigs of the reference assembly. This only applies to Mummer plots                      | `boolean` |         |          |        |
 | `synteny_color_by_contig`          | Mummer synteny plots are colored by contig. Otherwise, they are colored by bundle size                                                                                     | `boolean` | True    |          |        |
 | `synteny_plotsr_seq_label`         | Sequence label prefix for plotsr synteny                                                                                                                                   | `string`  | Chr     |          |        |
-| `synteny_plotsr_assembly_order`    | The order in which the assemblies should be compared, provided as space separated string of assembly tags. If absent, assemblies are ordered by their tags alphabetically. | `string`  |
-|                                    |                                                                                                                                                                            |           |
+| `synteny_plotsr_assembly_order`    | The order in which the assemblies should be compared, provided as space separated string of assembly tags. If absent, assemblies are ordered by their tags alphabetically. | `string`  |         |          |        |
 
 ## Merqury options
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,7 +62,7 @@ params {
     synteny_mummer_plot_type            = 'both'
     synteny_mummer_m2m_align            = false
     synteny_mummer_max_gap              = 1000000
-    synteny_mummer_min_bundle_size      = 1000
+    synteny_mummer_min_bundle_size      = 1000000
     synteny_plot_1_vs_all               = false
     synteny_color_by_contig             = true
     synteny_plotsr_seq_label            = 'Chr'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -214,7 +214,8 @@
                 "hic": {
                     "type": "string",
                     "description": "HiC reads path provided as a SRA ID or as paired reads such as 'hic_reads{1,2}.fastq.gz'",
-                    "pattern": "^SR\\w+$|^\\S+\\{1,2\\}[\\w\\.]*\\.f(ast)?q\\.gz$"
+                    "pattern": "^SR\\w+$|^\\S+\\{1,2\\}[\\w\\.]*\\.f(ast)?q\\.gz$",
+                    "fa_icon": "fas fa-copy"
                 },
                 "hic_skip_fastp": {
                     "type": "boolean",
@@ -292,7 +293,7 @@
                 },
                 "synteny_mummer_min_bundle_size": {
                     "type": "integer",
-                    "default": 1000,
+                    "default": 1000000,
                     "description": "After bundling, any Mummer alignment bundle smaller than this size is filtered out",
                     "fa_icon": "fas fa-ruler-horizontal"
                 },


### PR DESCRIPTION
…er_min_bundle_size to 1000000

<!--
# plant-food-research-open/assemblyqc pull request

Many thanks for contributing to plant-food-research-open/assemblyqc!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/plant-food-research-open/assemblyqc/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] Reduced the GenomeTools stats figures to 300 DPI and set `synteny_mummer_min_bundle_size` is set to `1000000`
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/plant-food-research-open/assemblyqc/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
