### PR TITLE
[GH-247] Sub-workflow FASTA_SEQKIT_REFSORT now works for n-genomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 13. Added parameter `hic_map_combinations` to allow creation of single and combined HiC maps in parallel [#220](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/220)
 14. Added parameter `hic_refsort` to make sorting by reference optional
 15. Added v3 of PFR test dataset [#240](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/240)
+16. Sub-workflow `FASTA_SEQKIT_REFSORT` now works for n-genome combinations [#247](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/247)
 
 ### `Fixed`
 

--- a/modules.json
+++ b/modules.json
@@ -22,7 +22,7 @@
                     },
                     "custom/interleavefasta": {
                         "branch": "main",
-                        "git_sha": "43ebc58b28509250ea4614c6ace26a258057d770",
+                        "git_sha": "6ce7bf4c7097a644610d3d6867551e629647839c",
                         "installed_by": ["fasta_seqkit_refsort"]
                     },
                     "custom/relabelfasta": {
@@ -169,7 +169,7 @@
                     },
                     "fasta_seqkit_refsort": {
                         "branch": "main",
-                        "git_sha": "02c04a56782504f92f9167bb5c1e93a2e1bac5b3",
+                        "git_sha": "f913b9b9a35bc41b041dc8fd13d6f3528741a21b",
                         "installed_by": ["subworkflows"]
                     },
                     "fastq_bwa_mem_samblaster": {

--- a/modules/gallvp/custom/interleavefasta/main.nf
+++ b/modules/gallvp/custom/interleavefasta/main.nf
@@ -8,10 +8,9 @@ process CUSTOM_INTERLEAVEFASTA {
         'biocontainers/biopython:1.75' }"
 
     input:
-    tuple val(meta), path(fasta1)
-    path(fasta2)
-    val(fasta1_prefix)
-    val(fasta2_prefix)
+    tuple val(meta), path(fastas)
+    val(fasta_prefixes)
+
 
     output:
     tuple val(meta), path("*.fasta")    , emit: fasta
@@ -22,12 +21,12 @@ process CUSTOM_INTERLEAVEFASTA {
 
     script:
     prefix = task.ext.prefix ?: "${meta.id}"
-    if ("${prefix}.fasta" == "$fasta1" || "${prefix}.fasta" == "$fasta2") error "Input and output names are the same, use 'prefix' to disambiguate!"
+    if ("${prefix}.fasta" in fastas) error "Input and output names are the same, use 'prefix' to disambiguate!"
     template 'interleave_fasta.py'
 
     stub:
     prefix = task.ext.prefix ?: "${meta.id}"
-    if ("${prefix}.fasta" == "$fasta1" || "${prefix}.fasta" == "$fasta2") error "Input and output names are the same, use 'prefix' to disambiguate!"
+    if ("${prefix}.fasta" in fastas) error "Input and output names are the same, use 'prefix' to disambiguate!"
     """
     touch ${prefix}.fasta
 

--- a/modules/gallvp/custom/interleavefasta/meta.yml
+++ b/modules/gallvp/custom/interleavefasta/meta.yml
@@ -1,7 +1,7 @@
----
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
 name: "custom_interleavefasta"
-description: Interleaves two FASTA files, optionally prefixing IDs if there are collisions, and outputs a single interleaved FASTA file.
+description: Interleaves two FASTA files, optionally prefixing IDs if there are
+  collisions, and outputs a single interleaved FASTA file.
 keywords:
   - fasta
   - interleave
@@ -28,28 +28,17 @@ input:
         description: |
           Groovy Map containing sample information
           e.g. `[ id:'sample1' ]`
-    - fasta1:
-        type: file
-        description: First input FASTA file
-        pattern: "*.fasta"
-        ontologies:
-          - edam: "http://edamontology.org/format_1929" # FASTA
-  - - fasta2:
-        type: file
-        description: Second input FASTA file
-        pattern: "*.fasta"
-        ontologies:
-          - edam: "http://edamontology.org/format_1929" # FASTA
-  - - fasta1_prefix:
-        type: string
-        description: Prefix to add to IDs from the first FASTA file if there are collisions
-  - - fasta2_prefix:
-        type: string
-        description: Prefix to add to IDs from the second FASTA file if there are collisions
+    - fastas:
+        type: list
+        description: A list of fasta files
+
+  - fasta_prefixes:
+      type: string
+      description: A space separated list of prefixes to add to IDs from the second FASTA file if there are collisions
 
 output:
-  - fasta:
-      - meta:
+  fasta:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -60,12 +49,14 @@ output:
           pattern: "*.fasta"
           ontologies:
             - edam: "http://edamontology.org/format_1929" # FASTA
-  - versions:
-      - "versions.yml":
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
 
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
 authors:
   - "@GallVp"
 maintainers:

--- a/modules/gallvp/custom/interleavefasta/templates/interleave_fasta.py
+++ b/modules/gallvp/custom/interleavefasta/templates/interleave_fasta.py
@@ -1,48 +1,53 @@
 #!/usr/bin/env python3
 
+import re
 from importlib.metadata import version
 from platform import python_version
 
 from Bio import SeqIO
 
-fasta1 = "$fasta1"
-fasta2 = "$fasta2"
-fasta1_prefix = "$fasta1_prefix"
-fasta2_prefix = "$fasta2_prefix"
-fasta_output_prefix = "$prefix"
-line_feed = "\\n"
-
 
 def main():
-    fasta1_records = list(SeqIO.parse(str(fasta1), "fasta"))
-    fasta2_records = list(SeqIO.parse(str(fasta2), "fasta"))
+    fasta_files_input = "$fastas"
+    prefixes_input = "$fasta_prefixes"
+    fasta_output_prefix = "$prefix"
 
-    fasta1_ids = {rec.id for rec in fasta1_records}
-    fasta2_ids = {rec.id for rec in fasta2_records}
-    n_fasta1 = len(fasta1_records)
-    n_fasta2 = len(fasta2_records)
-    max_n = max(n_fasta1, n_fasta2)
+    fasta_files = [f for f in re.split(r"[ ,;]", fasta_files_input) if f]
+    prefixes = [p for p in re.split(r"[ ,;]", prefixes_input) if p]
+    line_feed = "\\n"
 
-    should_prefix = bool(fasta1_ids & fasta2_ids)
-    fasta1_prefix_local = fasta1_prefix if should_prefix else ""
-    fasta2_prefix_local = fasta2_prefix if should_prefix else ""
+    all_records = []
+    all_ids = []
+    for fasta in fasta_files:
+        records = list(SeqIO.parse(str(fasta), "fasta"))
+        all_records.append(records)
+        all_ids.extend([rec.id for rec in records])
+
+    n_records_per_fasta = [len(records) for records in all_records]
+    max_n = max(n_records_per_fasta) if n_records_per_fasta else 0
+
+    should_prefix = len(set(all_ids)) != len(all_ids)
+
+    if should_prefix and (len(fasta_files) != len(prefixes)):
+        raise ValueError(
+            f"The number of prefixes ({len(prefixes)}) is not equal to the number of fasta files ({len(fasta_files)})!"
+        )
+
+    local_prefixes = prefixes if should_prefix else ["" for _ in range(0, len(fasta_files))]
 
     with open(f"{fasta_output_prefix}.fasta", "w") as out:
-        for i in range(max_n):
-            if i < n_fasta1:
-                rec = fasta1_records[i]
-                rec_id = f"{fasta1_prefix_local}{rec.id}"
-                out.write(f">{rec_id}{line_feed}{str(rec.seq)}{line_feed}")
-            if i < n_fasta2:
-                rec = fasta2_records[i]
-                rec_id = f"{fasta2_prefix_local}{rec.id}"
-                out.write(f">{rec_id}{line_feed}{str(rec.seq)}{line_feed}")
+        for record_idx in range(max_n):
+            for fasta_idx, fasta_records in enumerate(all_records):
+                if record_idx < len(fasta_records):
+                    rec = fasta_records[record_idx]
+                    rec_id = f"{local_prefixes[fasta_idx]}{rec.id}"
+                    out.write(f">{rec_id}{line_feed}{str(rec.seq)}{line_feed}")
 
     # Write versions
     with open("versions.yml", "w") as f_versions:
         f_versions.write('"${task.process}":\\n')
-        f_versions.write(f"    python: {python_version()}\\n")
-        f_versions.write(f"    biopython: {version('biopython')}\\n")
+        f_versions.write(f"    python: {python_version()}{line_feed}")
+        f_versions.write(f"    biopython: {version('biopython')}{line_feed}")
 
 
 if __name__ == "__main__":

--- a/modules/gallvp/custom/interleavefasta/tests/main.nf.test
+++ b/modules/gallvp/custom/interleavefasta/tests/main.nf.test
@@ -19,10 +19,8 @@ nextflow_process {
                 def test2_fasta = new File("test2.fasta")
                 test2_fasta.text = ">b1\\nAAAA\\n>b2\\nCCCC\\n"
 
-                input[0] = [ [ id: 'test'], test1_fasta.toPath() ]
-                input[1] = [ test2_fasta.toPath() ]
-                input[2] = '' // fasta1_prefix
-                input[3] = '' // fasta2_prefix
+                input[0] = [ [ id: 'test'], [ test1_fasta.toPath(), test2_fasta.toPath() ] ]
+                input[1] = ''
                 """
             }
         }
@@ -44,10 +42,8 @@ nextflow_process {
                 def test2_fasta = new File("test2.fasta")
                 test2_fasta.text = ">b1\\nAAAA\\n"
 
-                input[0] = [ [ id: 'test'], test1_fasta.toPath() ]
-                input[1] = [ test2_fasta.toPath() ]
-                input[2] = '' // fasta1_prefix
-                input[3] = '' // fasta2_prefix
+                input[0] = [ [ id: 'test'], [ test1_fasta.toPath(), test2_fasta.toPath() ] ]
+                input[1] = ''
                 """
             }
         }
@@ -68,10 +64,8 @@ nextflow_process {
                 def test2_fasta = new File("test2.fasta")
                 test2_fasta.text = ">id1\\nCCC\\n"
 
-                input[0] = [ [ id: 'test'], test1_fasta.toPath() ]
-                input[1] = [ test2_fasta.toPath() ]
-                input[2] = 'A_' // fasta1_prefix
-                input[3] = 'B_' // fasta2_prefix
+                input[0] = [ [ id: 'test'], [ test1_fasta.toPath(), test2_fasta.toPath() ] ]
+                input[1] = 'A_ B_'
                 """
             }
         }
@@ -79,6 +73,49 @@ nextflow_process {
             assert process.success
             assert file(process.out.fasta[0][1]).text == ">A_id1\nAAA\n>B_id1\nCCC\n"
             assert snapshot(process.out).match()
+        }
+    }
+
+    test("interleavefasta - five files") {
+        when {
+            process {
+                """
+                def f1 = new File("f1.fasta"); f1.text = ">id\\nA\\n"
+                def f2 = new File("f2.fasta"); f2.text = ">id\\nB\\n"
+                def f3 = new File("f3.fasta"); f3.text = ">id\\nC\\n"
+                def f4 = new File("f4.fasta"); f4.text = ">id\\nD\\n"
+                def f5 = new File("f5.fasta"); f5.text = ">id\\nE\\n"
+
+                input[0] = [ [ id: 'test'], [ f1.toPath(), f2.toPath(), f3.toPath(), f4.toPath(), f5.toPath() ] ]
+                input[1] = 'P1_ P2_ P3_ P4_ P5_'
+                """
+            }
+        }
+        then {
+            assert process.success
+            assert file(process.out.fasta[0][1]).text == ">P1_id\nA\n>P2_id\nB\n>P3_id\nC\n>P4_id\nD\n>P5_id\nE\n"
+            assert snapshot(process.out).match()
+        }
+    }
+
+    test("interleavefasta - id collision triggers prefix - fails due to no prefix input") {
+        when {
+            process {
+                """
+                def test1_fasta = new File("test1.fasta")
+                test1_fasta.text = ">id1\\nAAA\\n"
+
+                def test2_fasta = new File("test2.fasta")
+                test2_fasta.text = ">id1\\nCCC\\n"
+
+                input[0] = [ [ id: 'test'], [ test1_fasta.toPath(), test2_fasta.toPath() ] ]
+                input[1] = ''
+                """
+            }
+        }
+        then {
+            assert ! process.success
+            assert process.stdout.toString().contains( 'is not equal to the number of fasta files' )
         }
     }
 

--- a/modules/gallvp/custom/interleavefasta/tests/main.nf.test.snap
+++ b/modules/gallvp/custom/interleavefasta/tests/main.nf.test.snap
@@ -97,5 +97,38 @@
             "nextflow": "25.04.4"
         },
         "timestamp": "2025-07-01T12:19:20.624811"
+    },
+    "interleavefasta - five files": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,351155e045aaf4e93cdf2481b9392047"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,d068b70bd89339c1cf161f53f987eb6b"
+                ],
+                "fasta": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,351155e045aaf4e93cdf2481b9392047"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,d068b70bd89339c1cf161f53f987eb6b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-10T14:12:56.718248"
     }
 }

--- a/subworkflows/gallvp/fasta_seqkit_refsort/main.nf
+++ b/subworkflows/gallvp/fasta_seqkit_refsort/main.nf
@@ -24,94 +24,94 @@ workflow FASTA_SEQKIT_REFSORT {
                                             : ch_fasta
     ch_versions                             = ch_versions.mix(SEQKIT_SORT.out.versions.first())
 
-    // Channels: ch_grouped_fastas, ch_single_fasta, ch_paired_fastas, ch_refsort_paired_fastas
-    ch_combinations_list                    = ( val_fasta_combinations == null || val_fasta_combinations == [] )
+    // Channels: ch_grouped_fastas, ch_single_fasta, ch_paired_fastas, ch_minimap_inputs
+    ch_combinations                         = ( val_fasta_combinations == null || val_fasta_combinations == [] )
                                             ? ch_fasta
                                             | map { meta, _fasta -> meta.id }
-                                            | collect
                                             : Channel.of(
                                                 val_fasta_combinations.tokenize( ' ' )
                                             )
+                                            | flatten
 
     ch_grouped_fastas                       = ch_sorted_fasta
-                                            | combine (
-                                                ch_combinations_list
-                                                | flatten
-                                            )
+                                            | combine ( ch_combinations )
                                             | filter { meta, _fasta, comb -> meta.id in comb.tokenize( ':' ) }
                                             | map { meta, fasta, comb ->
-                                                [ comb, meta, fasta ]
+                                                [ comb, meta + [ comb: comb ], fasta ] // meta2: meta + [comb:]
                                             }
                                             | groupTuple
-                                            | map { group_key, metas, fastas ->
-
-                                                if ( metas.size() == 1 ) {
-                                                    return [ metas, fastas ]
-                                                }
-
-                                                def group_ids = group_key.tokenize(':')
-                                                def meta_ids = metas.collect { it.id }
-
-                                                def query_id = group_ids.first()
-                                                def ref_id = group_ids.last()
-
-                                                def query_i = meta_ids.indexOf( query_id )
-                                                def ref_i = meta_ids.indexOf( ref_id )
-
-                                                def ordered_fastas = [
-                                                    fastas[query_i],
-                                                    fastas[ref_i],
-                                                ]
-
-                                                def new_id = group_ids.join('_')
-
-                                                [
-                                                    [ id: new_id, query: query_id, ref: ref_id ], // meta2
-                                                    ordered_fastas
-                                                ]
-                                            }
-                                            | branch { _meta2, fastas ->
-                                                single: fastas.size() != 2
-                                                paired: fastas.size() == 2
+                                            | branch { _comb, _metas2, fastas ->
+                                                single: fastas.size() == 1
+                                                multi: fastas.size() > 1
                                             }
 
     ch_single_fasta                         = ch_grouped_fastas.single
-                                            | map { meta, fastas ->
-                                                [ meta.first(), fastas.first() ]
+                                            | map { _comb, metas2, fastas ->
+                                                [ metas2.first(), fastas.first() ]
                                             }
 
-    ch_paired_fastas                        = ch_grouped_fastas.paired
-    ch_refsort_paired_fastas                = val_refsort
-                                            ? ch_grouped_fastas.paired
-                                            : Channel.empty()
+    ch_paired_fastas                        = ch_grouped_fastas.multi
+                                            | flatMap { comb, metas2, fastas ->
+
+                                                def comb_ids = comb.tokenize(':') // ordered
+                                                def meta_ids = metas2.collect { it.id } // unordered
+
+                                                def ref_id = comb_ids.last()
+                                                def query_ids = comb_ids[0..-2]
+
+                                                def ref_fasta = fastas[ meta_ids.indexOf( ref_id ) ]
+
+                                                query_ids.collect { it ->
+                                                    [
+                                                        id: "${it}_${ref_id}",
+                                                        comb: comb,
+                                                        pair: "${it}:${ref_id}",
+                                                        fastas: [ fastas[ meta_ids.indexOf( it ) ], ref_fasta ]
+                                                    ]
+                                                }
+                                            }
+                                            | map { box ->
+                                                [
+                                                    [
+                                                        id: box.id,
+                                                        comb: box.comb,
+                                                        pair: box.pair
+                                                    ],
+                                                    box.fastas
+                                                ]
+                                            }
+
 
     // MODULE: MINIMAP2_ALIGN; ext.args = -x asm5 --secondary=no
+    ch_minimap_inputs                       = val_refsort
+                                            ? ch_paired_fastas
+                                            : Channel.empty()
     MINIMAP2_ALIGN (
-        ch_refsort_paired_fastas.map { meta2, fastas -> [ meta2, fastas.first() ] },
-        ch_refsort_paired_fastas.map { meta2, fastas -> [ meta2, fastas.last() ] },
-        false, // bam_format
-        [], // bam_format
-        false, // cigar_paf_format
-        false // cigar_bam
+        ch_minimap_inputs.map { meta2, fastas -> [ meta2, fastas.first() ] },
+        ch_minimap_inputs.map { meta2, fastas -> [ meta2, fastas.last() ] },
+        false,  // bam_format
+        [],     // bam_format
+        false,  // cigar_paf_format
+        false   // cigar_bam
     )
 
-    ch_refsort_paired_fastas_paf            = ch_refsort_paired_fastas
-                                            | join ( MINIMAP2_ALIGN.out.paf )
+    ch_minimap_inputs_paf                   = ch_minimap_inputs
+                                            | join(MINIMAP2_ALIGN.out.paf)
     ch_versions                             = ch_versions.mix(MINIMAP2_ALIGN.out.versions.first())
 
     // JUICEBOXSCRIPTS_MAKEAGPFROMFASTA
     JUICEBOXSCRIPTS_MAKEAGPFROMFASTA (
-        ch_refsort_paired_fastas.map { meta2, fastas -> [ meta2, fastas.first() ] }
+        ch_minimap_inputs.map { meta2, fastas -> [ meta2, fastas.first() ] }
     )
 
-    ch_refsort_paired_fastas_paf_query_agp  = ch_refsort_paired_fastas_paf
+    ch_minimap_inputs_paf_agp               = ch_minimap_inputs_paf
                                             | join(
                                                 JUICEBOXSCRIPTS_MAKEAGPFROMFASTA.out.agp
                                             )
     ch_versions                             = ch_versions.mix(JUICEBOXSCRIPTS_MAKEAGPFROMFASTA.out.versions.first())
 
     // MODULE: HAPHIC_REFSORT
-    ch_refsort_inputs                       = ch_refsort_paired_fastas_paf_query_agp
+    ch_refsort_inputs                       = ch_minimap_inputs_paf_agp
                                             | multiMap { meta2, fastas, paf, query_agp ->
                                                 agp:    [ meta2, query_agp ]
                                                 paf:    paf
@@ -124,13 +124,13 @@ workflow FASTA_SEQKIT_REFSORT {
         [] //ref_order
     )
 
-    ch_refsort_paired_fastas_refsort_fasta  = ch_refsort_paired_fastas
+    ch_minimap_inputs_refsort_fasta         = ch_minimap_inputs
                                             | join ( HAPHIC_REFSORT.out.fasta )
     ch_versions                             = ch_versions.mix(HAPHIC_REFSORT.out.versions.first())
 
-    // Channel: ch_ref_sorted_paired_fastas
-    ch_ref_sorted_paired_fastas             = val_refsort
-                                            ? ch_refsort_paired_fastas_refsort_fasta
+    // Channel: ch_refsort_pairs
+    ch_refsort_pairs                        = val_refsort
+                                            ? ch_minimap_inputs_refsort_fasta
                                             | map { meta2, fastas, refsort_fasta ->
                                                 [
                                                     meta2,
@@ -140,25 +140,33 @@ workflow FASTA_SEQKIT_REFSORT {
                                             : ch_paired_fastas
 
     // MODULE:CUSTOM_INTERLEAVEFASTA
-    ch_interleave_input                     = ch_ref_sorted_paired_fastas
-                                            | multiMap { meta2, fastas ->
-                                                def query_fasta = fastas.first()
-                                                def ref_fasta  = fastas.last()
+    ch_interleave_input                     = ch_refsort_pairs
+                                            | map { meta2, fastas ->
+                                                [
+                                                    meta2.comb,
+                                                    meta2,
+                                                    fastas
+                                                ]
+                                            }
+                                            | groupTuple
+                                            | multiMap { comb, metas2, fastas ->
+                                                def unordered_fastas = fastas.collect { it.first() } + [ fastas.first().last() ]
 
-                                                def query_prefix = meta2.query
-                                                def ref_prefix = meta2.ref
+                                                def unordered_ids = metas2.collect { meta -> meta.pair.tokenize(':').first() } + [ comb.tokenize(':').last() ]
+                                                def ordered_ids = comb.tokenize(':')
 
-                                                fasta1:         [ [ id: meta2.id ], query_fasta ]
-                                                fasta2:         ref_fasta
-                                                fasta1_prefix:  query_prefix
-                                                fasta2_prefix:  ref_prefix
+
+                                                fastas: [
+                                                        [ id: comb.tokenize(':').join('_'), comb: comb ],
+                                                        ordered_ids.collect { id -> unordered_fastas[ unordered_ids.indexOf( id ) ] }
+                                                    ]
+                                                prefixes: ordered_ids.join( ' ' )
                                             }
 
+
     CUSTOM_INTERLEAVEFASTA (
-        ch_interleave_input.fasta1,
-        ch_interleave_input.fasta2,
-        ch_interleave_input.fasta1_prefix,
-        ch_interleave_input.fasta2_prefix,
+        ch_interleave_input.fastas,
+        ch_interleave_input.prefixes
     )
 
     ch_interleaved_fasta                    = CUSTOM_INTERLEAVEFASTA.out.fasta
@@ -166,6 +174,6 @@ workflow FASTA_SEQKIT_REFSORT {
 
     emit:
     fasta                                   = ch_interleaved_fasta
-                                            | mix ( ch_single_fasta )   // channel: [ meta3, fasta ]; meta3 ~ [ id ]
+                                            | mix ( ch_single_fasta )   // channel: [ meta3, fasta ]; meta3 ~ [ id, comb ]
     versions                                = ch_versions               // channel: [ versions.yml ]
 }

--- a/subworkflows/gallvp/fasta_seqkit_refsort/tests/main.nf.test
+++ b/subworkflows/gallvp/fasta_seqkit_refsort/tests/main.nf.test
@@ -27,6 +27,10 @@ nextflow_workflow {
                         file('https://github.com/Plant-Food-Research-Open/assemblyqc/raw/4f9fba392cf7212d61c6245fd72339e09164ce44/tests/hic/testdata/HYh1h2_Chr01_6000000_6015000.fasta.gz')
                     ],
                     [
+                        [ id: 'query1' ],
+                        file('https://github.com/Plant-Food-Research-Open/assemblyqc/raw/4f9fba392cf7212d61c6245fd72339e09164ce44/tests/hic/testdata/HYh1h2_Chr01_6000000_6015000.fasta.gz')
+                    ],
+                    [
                         [ id: 'ref' ],
                         file(params.modules_testdata_base_path + 'genomics/eukaryotes/actinidia_chinensis/genome/chr1/genome.fasta.gz', checkIfExists: true)
                     ],
@@ -65,6 +69,27 @@ nextflow_workflow {
                 """
                 input[0] = GUNZIP.out.gunzip
                 input[1] = "query query:ref ref"
+                input[2] = true
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(workflow.out).match()}
+            )
+        }
+    }
+
+    test("HY - actinidia_chinensis - fasta - combinations - 3") {
+
+        when {
+            workflow {
+                """
+                input[0] = GUNZIP.out.gunzip
+                input[1] = "query query1:query:ref ref"
                 input[2] = true
                 input[3] = true
                 """

--- a/subworkflows/gallvp/fasta_seqkit_refsort/tests/main.nf.test.snap
+++ b/subworkflows/gallvp/fasta_seqkit_refsort/tests/main.nf.test.snap
@@ -5,19 +5,22 @@
                 "0": [
                     [
                         {
-                            "id": "query_ref"
-                        },
-                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
-                    ],
-                    [
-                        {
-                            "id": "query"
+                            "id": "query",
+                            "comb": "query"
                         },
                         "HYh1h2_Chr01_6000000_6015000.fasta:md5,698715c5989f43041a04f6fdca846974"
                     ],
                     [
                         {
-                            "id": "ref"
+                            "id": "query_ref",
+                            "comb": "query:ref"
+                        },
+                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
                         },
                         "genome.fasta:md5,d07bc737a8ba2db4ea02872a73dace0b"
                     ]
@@ -28,19 +31,22 @@
                 "fasta": [
                     [
                         {
-                            "id": "query_ref"
-                        },
-                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
-                    ],
-                    [
-                        {
-                            "id": "query"
+                            "id": "query",
+                            "comb": "query"
                         },
                         "HYh1h2_Chr01_6000000_6015000.fasta:md5,698715c5989f43041a04f6fdca846974"
                     ],
                     [
                         {
-                            "id": "ref"
+                            "id": "query_ref",
+                            "comb": "query:ref"
+                        },
+                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
                         },
                         "genome.fasta:md5,d07bc737a8ba2db4ea02872a73dace0b"
                     ]
@@ -52,9 +58,80 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-02T10:18:34.182968"
+        "timestamp": "2025-07-14T11:19:18.988874"
+    },
+    "HY - actinidia_chinensis - fasta - combinations - 3": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "query",
+                            "comb": "query"
+                        },
+                        "query.fasta:md5,bcc14495671d77033b36be11fc20652c"
+                    ],
+                    [
+                        {
+                            "id": "query1_query_ref",
+                            "comb": "query1:query:ref"
+                        },
+                        "query1_query_ref.fasta:md5,312e4da3d66e0003300787af18b9bc59"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
+                        },
+                        "ref.fasta:md5,7315276c0e677b424e673562f48b9873"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,0b0eba6b6f07300cd87c276e0a55424d",
+                    "versions.yml:md5,5772594d0b3e1f41b2730f1dda23465b",
+                    "versions.yml:md5,7cd4eb452407fcd946428f758c97442d",
+                    "versions.yml:md5,c2aa26eec40ab4040601c089970c815c",
+                    "versions.yml:md5,c8fc50b7f6a91b026265c5202a63fbc7"
+                ],
+                "fasta": [
+                    [
+                        {
+                            "id": "query",
+                            "comb": "query"
+                        },
+                        "query.fasta:md5,bcc14495671d77033b36be11fc20652c"
+                    ],
+                    [
+                        {
+                            "id": "query1_query_ref",
+                            "comb": "query1:query:ref"
+                        },
+                        "query1_query_ref.fasta:md5,312e4da3d66e0003300787af18b9bc59"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
+                        },
+                        "ref.fasta:md5,7315276c0e677b424e673562f48b9873"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,0b0eba6b6f07300cd87c276e0a55424d",
+                    "versions.yml:md5,5772594d0b3e1f41b2730f1dda23465b",
+                    "versions.yml:md5,7cd4eb452407fcd946428f758c97442d",
+                    "versions.yml:md5,c2aa26eec40ab4040601c089970c815c",
+                    "versions.yml:md5,c8fc50b7f6a91b026265c5202a63fbc7"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-14T11:24:39.1962"
     },
     "HY - actinidia_chinensis - fasta": {
         "content": [
@@ -62,13 +139,22 @@
                 "0": [
                     [
                         {
-                            "id": "query"
+                            "id": "query",
+                            "comb": "query"
                         },
                         "query.fasta:md5,bcc14495671d77033b36be11fc20652c"
                     ],
                     [
                         {
-                            "id": "ref"
+                            "id": "query1",
+                            "comb": "query1"
+                        },
+                        "query1.fasta:md5,bcc14495671d77033b36be11fc20652c"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
                         },
                         "ref.fasta:md5,7315276c0e677b424e673562f48b9873"
                     ]
@@ -79,13 +165,22 @@
                 "fasta": [
                     [
                         {
-                            "id": "query"
+                            "id": "query",
+                            "comb": "query"
                         },
                         "query.fasta:md5,bcc14495671d77033b36be11fc20652c"
                     ],
                     [
                         {
-                            "id": "ref"
+                            "id": "query1",
+                            "comb": "query1"
+                        },
+                        "query1.fasta:md5,bcc14495671d77033b36be11fc20652c"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
                         },
                         "ref.fasta:md5,7315276c0e677b424e673562f48b9873"
                     ]
@@ -97,9 +192,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-06-23T16:37:58.264534"
+        "timestamp": "2025-07-14T14:50:26.212818"
     },
     "HY - actinidia_chinensis - fasta - combinations": {
         "content": [
@@ -107,19 +202,22 @@
                 "0": [
                     [
                         {
-                            "id": "query_ref"
-                        },
-                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
-                    ],
-                    [
-                        {
-                            "id": "query"
+                            "id": "query",
+                            "comb": "query"
                         },
                         "query.fasta:md5,bcc14495671d77033b36be11fc20652c"
                     ],
                     [
                         {
-                            "id": "ref"
+                            "id": "query_ref",
+                            "comb": "query:ref"
+                        },
+                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
                         },
                         "ref.fasta:md5,7315276c0e677b424e673562f48b9873"
                     ]
@@ -134,19 +232,22 @@
                 "fasta": [
                     [
                         {
-                            "id": "query_ref"
-                        },
-                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
-                    ],
-                    [
-                        {
-                            "id": "query"
+                            "id": "query",
+                            "comb": "query"
                         },
                         "query.fasta:md5,bcc14495671d77033b36be11fc20652c"
                     ],
                     [
                         {
-                            "id": "ref"
+                            "id": "query_ref",
+                            "comb": "query:ref"
+                        },
+                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
                         },
                         "ref.fasta:md5,7315276c0e677b424e673562f48b9873"
                     ]
@@ -162,8 +263,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-02T10:18:26.935545"
+        "timestamp": "2025-07-14T11:18:57.443951"
     }
 }


### PR DESCRIPTION
<!--
# plant-food-research-open/assemblyqc pull request

Many thanks for contributing to plant-food-research-open/assemblyqc!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/plant-food-research-open/assemblyqc/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] [GH-247] Sub-workflow FASTA_SEQKIT_REFSORT now works for n-genome combinations
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/plant-food-research-open/assemblyqc/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
