### PR TITLE
[GH-258] Added '-n' for assembly mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v3.0.0dev - [15-July-2025]
+## v3.0.0dev - [16-July-2025]
 
 ### `Added`
 
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 7. Fixed an issue where `hic_map_combinations` parameter did not allow `tag1:tag2` [#236](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/236)
 8. Fixed an issue where the HiC map did not correctly load the track annotations [#238](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/238)
 9. Fixed an issue where the Nextflow head job was consuming more than 4.GB due to an fasta interleaving workflow being run on `exec:` [#239](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/239)
+10. Fixed an issue where the pipeline crashed when the `hic_assembly_mode` was set to `true` [#258](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/258)
 
 ### `Deprecated`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -403,7 +403,10 @@ process {
 
         ext.prefix = { "${meta.ref_id}" }
 
-        ext.args = params.hic_juicer_tools_pre_ext_args
+        ext.args = [
+            params.hic_assembly_mode ? '-n' : '',
+            params.hic_juicer_tools_pre_ext_args ? params.hic_juicer_tools_pre_ext_args.split("\\s(?=-)") : ''
+        ].flatten().unique(false).join(' ').trim()
 
         publishDir = [
             path: { "${params.outdir}/hic" },

--- a/subworkflows/local/utils_nfcore_assemblyqc_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_assemblyqc_pipeline/main.nf
@@ -163,6 +163,14 @@ workflow PIPELINE_INITIALISATION {
     ch_params_as_json                       = Channel.of ( jsonifyParams ( params ) )
     ch_summary_params_as_json               = Channel.of ( jsonifySummaryParams ( summary_params ) )
 
+    // Print parameter warnings
+    if ( params.hic_assembly_mode ) {
+        def msg = "Parameter 'hic_assembly_mode' is set to 'true'. To avoid pipeline crash at the " +
+            "JUICERTOOLS_PRE step, '-n' has been added to the arguments for the 'juicer_tools pre' command " +
+            "which disables HiC map normalizations. https://github.com/Plant-Food-Research-Open/assemblyqc/issues/258"
+        log.warn ( msg )
+    }
+
     emit:
     input                                   = ch_input_validated
     hic_reads                               = ch_hic_reads

--- a/tests/hic/main.nf.test
+++ b/tests/hic/main.nf.test
@@ -61,7 +61,6 @@ nextflow_pipeline {
                 input                           = "$baseDir/tests/hic/assemblysheet.csv"
                 hic                             = "$baseDir/tests/hic/testdata/HYh1h2_Chr01_6000000_6015000.R{1,2}.fastq.gz"
                 hic_assembly_mode               = true
-                hic_juicer_tools_pre_ext_args   = '-n'
                 outdir                          = "$outputDir"
             }
         }
@@ -94,6 +93,9 @@ nextflow_pipeline {
 
             assertAll(
                 { assert workflow.success},
+                {
+                    assert workflow.stdout.toString().contains( "WARN: Parameter 'hic_assembly_mode' is set to 'true'. To avoid pipeline crash" )
+                },
                 { assert snapshot(
                     [
                         'successful tasks': workflow.trace.succeeded().size(),


### PR DESCRIPTION
<!--
# plant-food-research-open/assemblyqc pull request

Many thanks for contributing to plant-food-research-open/assemblyqc!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/plant-food-research-open/assemblyqc/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] [GH-258] Added '-n' for assembly mode
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/plant-food-research-open/assemblyqc/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
