### PR TITLE
assemblathon fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 8. Fixed an issue where the HiC map did not correctly load the track annotations [#238](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/238)
 9. Fixed an issue where the Nextflow head job was consuming more than 4.GB due to an fasta interleaving workflow being run on `exec:` [#239](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/239)
 10. Fixed an issue where the pipeline crashed when the `hic_assembly_mode` was set to `true` [#258](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/258)
+11. Fixed an issue where assemblathon was crashing on MMC due to `xargs -I {} find {} -maxdepth 0 -print 2>/dev/null`. 
 
 ### `Deprecated`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 8. Fixed an issue where the HiC map did not correctly load the track annotations [#238](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/238)
 9. Fixed an issue where the Nextflow head job was consuming more than 4.GB due to an fasta interleaving workflow being run on `exec:` [#239](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/239)
 10. Fixed an issue where the pipeline crashed when the `hic_assembly_mode` was set to `true` [#258](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/258)
-11. Fixed an issue where assemblathon was crashing on MMC due to `xargs -I {} find {} -maxdepth 0 -print 2>/dev/null`. 
+11. Fixed an issue where assemblathon was crashing on MMC due to `xargs -I {} find {} -maxdepth 0 -print 2>/dev/null`.
 
 ### `Deprecated`
 

--- a/modules/local/assemblathon_stats.nf
+++ b/modules/local/assemblathon_stats.nf
@@ -22,7 +22,7 @@ process ASSEMBLATHON_STATS {
     def VERSION = "github/PlantandFoodResearch/assemblathon2-analysis/a93cba2"
     """
     paths_to_check=\$(printf "%s\\n" \$(echo \$PATH | tr ':' ' ') \\
-        | xargs -I {} find {} -maxdepth 0 -print 2>/dev/null \\
+        | awk 'system("[ -d \"" $0 "\" ]") == 0' \\
         | grep -v '^\$' \\
         | grep -v '/sbin' \\
         | xargs

--- a/modules/local/assemblathon_stats.nf
+++ b/modules/local/assemblathon_stats.nf
@@ -22,7 +22,7 @@ process ASSEMBLATHON_STATS {
     def VERSION = "github/PlantandFoodResearch/assemblathon2-analysis/a93cba2"
     """
     paths_to_check=\$(printf "%s\\n" \$(echo \$PATH | tr ':' ' ') \\
-        | awk 'system("[ -d \"" $0 "\" ]") == 0' \\
+        | awk 'system("[ -d \\"" \$0 "\\" ]") == 0' \\
         | grep -v '^\$' \\
         | grep -v '/sbin' \\
         | xargs


### PR DESCRIPTION
Fixed an issue where assemblathon was crashing on MMC due to `xargs -I {} find {} -maxdepth 0 -print 2>/dev/null`. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/plant-food-research-open/assemblyqc/tree/main/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
