### PR TITLE
[GH-294] Now computing GC content only for the assemblies with reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v3.0.0dev - [19-Aug-2025]
+## v3.0.0dev - [21-Aug-2025]
 
 ### `Added`
 
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 12. Fixed an issue where `JUICERTOOLS_PRE` was not requesting the right ammount of memory [#268](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/268)
 13. ~~Added `JUICER_INDEXBYCHR` to the HiC workflow so that `JUICERTOOLS_PRE` uses multiple threads [#273](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/273)~~ This change lead to a broken HiC map and was, therefore, rolled back.
 14. Fixed an issue where the HiC map did not load correctly on Firefox [#274](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/274)
+15. Fixed an issue where the GC content was computed for all the assemblies instead of only those that had reads available for computing coverage [#294](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/294)
 
 ### `Deprecated`
 

--- a/tests/mapback/assemblysheet.csv
+++ b/tests/mapback/assemblysheet.csv
@@ -1,3 +1,3 @@
 tag,fasta,reads_1
-sarscov2,https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/sarscov2/genome/genome.fasta.gz,https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/sarscov2/nanopore/fastq/test.fastq.gz
+sarscov2,https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/sarscov2/genome/genome.fasta.gz,
 bacteroides_fragilis,https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz,https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/prokaryotes/bacteroides_fragilis/nanopore/fastq/test.fastq.gz

--- a/tests/mapback/main.nf.test.snap
+++ b/tests/mapback/main.nf.test.snap
@@ -2,7 +2,7 @@
     "mapback": {
         "content": [
             {
-                "successful tasks": 27,
+                "successful tasks": 20,
                 "versions": {
                     "ASSEMBLATHON_STATS": {
                         "assemblathon_stats": "github/PlantandFoodResearch/assemblathon2-analysis/a93cba2"
@@ -49,9 +49,7 @@
                     "bacteroides_fragilis_stats.csv:md5,081d707dd9fc92db7b4706b4a0d78ec0",
                     "sarscov2_stats.csv:md5,9ec4147b73cae550a38337520fc028dd",
                     "bacteroides_fragilis.bed:md5,b264a651b31ddf2b2ec326a8d209a10d",
-                    "bacteroides_fragilis.cov.wig:md5,1239e86511111eefab50440e17c778cb",
-                    "sarscov2.bed:md5,977c49e01f2c64deb42bb32398b0c3c9",
-                    "sarscov2.cov.wig:md5,19bcbd9726c8b40c3e117e0a59855643"
+                    "bacteroides_fragilis.cov.wig:md5,1239e86511111eefab50440e17c778cb"
                 ]
             }
         ],
@@ -59,6 +57,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-08-19T18:16:33.209133"
+        "timestamp": "2025-08-21T09:37:48.377459"
     }
 }


### PR DESCRIPTION
<!--
# plant-food-research-open/assemblyqc pull request

Many thanks for contributing to plant-food-research-open/assemblyqc!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/plant-food-research-open/assemblyqc/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] GH-294
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/plant-food-research-open/assemblyqc/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
