### PR TITLE
[GH-307] Fixed an issue where the x-axis ticks were not displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v3.0.0dev - [05-Sep-2025]
+## v3.0.0dev - [15-Sep-2025]
 
 ### `Added`
 
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 26. Added module `CLAIR3` for variant calling [#300](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/300)
 27. Added parameters `mapback_coverage_span_bp` and `mapback_gc_het_window_bp` to provide more control over Mapback stats generation and plotting [#304](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/304)
 28. Fixed the Mapback scales to 2x/3x mean of data [#299](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/299)
+29. Added mean and 1/2 mean guides for the coverage plot [#307](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/307)
 
 ### `Fixed`
 
@@ -54,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 14. Fixed an issue where the HiC map did not load correctly on Firefox [#274](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/274)
 15. Fixed an issue where the GC content was computed for all the assemblies instead of only those that had reads available for computing coverage [#294](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/294)
 16. Fixed an issue where Mapback report module failed when variant calling was skipped [#302](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/302)
+17. Fixed an issue where the x-axis ticks were not displayed for the coverage plot [#307](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/307)
 
 ### `Deprecated`
 

--- a/bin/report_modules/parsers/mapback_parser.py
+++ b/bin/report_modules/parsers/mapback_parser.py
@@ -169,20 +169,24 @@ def plot_contig_profile(
     cov_filter_len: int = (
         2 * int(mapback_rolling_median_bp / mapback_coverage_span_bp / 2) + 1
     )
-    coverages_mm: list[float] = (
+    coverages_mm = (
         pd.Series(coverages)
         .rolling(window=cov_filter_len, center=True, min_periods=1)
         .median()
-        .to_list()
     )
-    ax_cov.plot(positions, coverages_mm, color="blue", label="Coverage")
+    coverages_mm_mean: float = coverages_mm.where(coverages_mm > 0).dropna().mean()
+    coverages_mm_mean_half = coverages_mm_mean * 0.5
+
+    ax_cov.plot(positions, coverages_mm.tolist(), color="blue", label="Coverage")
+    ax_cov.axhline(y=coverages_mm_mean, color="black", linestyle=":", linewidth=1)
+    ax_cov.axhline(y=coverages_mm_mean_half, color="black", linestyle=":", linewidth=1)
     ax_cov.set_ylabel("Coverage", color="blue")
     ax_cov.tick_params(axis="y", labelcolor="blue")
     ax_cov.set_ylim(0, coverage_max)
     ax_cov.spines["top"].set_visible(False)
     ax_cov.spines["right"].set_visible(False)
     ax_cov.xaxis.set_major_locator(MaxNLocator(nbins=15))
-    ax_cov.get_xaxis().set_visible(False)
+    ax_cov.get_xaxis().set_visible(False if het_stats else True)
 
     # 0/1 GT Count plot
     if het_stats:


### PR DESCRIPTION
<!--
# plant-food-research-open/assemblyqc pull request

Many thanks for contributing to plant-food-research-open/assemblyqc!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/plant-food-research-open/assemblyqc/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] GH-307
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/plant-food-research-open/assemblyqc/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
