### PR TITLE
[Not Implimented] removing BWA_MEM sorting

### DIFF
--- a/.github/workflows/linting_comment.yml
+++ b/.github/workflows/linting_comment.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo "pr_number=$(cat linting-logs/PR_number.txt)" >> $GITHUB_OUTPUT
 
       - name: Post PR comment
-        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.pr_number.outputs.pr_number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 1. Added disk cleanup to nf-test GitHub CI action to avoid the runner running out of disk space for `full - stub` runs
+2. Added hic.bam file speedup by skipping name sort.
 
 ### `Fixed`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -358,7 +358,7 @@ process {
     withName: '.*:FQ2HIC:FASTQ_BWA_MEM_SAMBLASTER:BWA_MEM' {
         ext.prefix = { "${meta.id}.on.${meta.ref_id}.bwa.mem" }
         ext.args = '-5SP'
-        ext.args2 = '-n'
+        // ext.args2 = '-n'
     }
 
     withName: '.*:FQ2HIC:FASTQ_BWA_MEM_SAMBLASTER:SAMBLASTER' {

--- a/docs/output.md
+++ b/docs/output.md
@@ -183,7 +183,7 @@ Kraken 2 [assigns taxonomic labels](https://ccb.jhu.edu/software/kraken2/) to se
     - `*_1_fastqc.html/*_2_fastqc.html`: FastQC html report for the reads passed by FASTP.
     - `*_1_fastqc.zip/*_2_fastqc.zip`: FastQC stats for the reads passed by FASTP.
   - `hicqc`
-    - `*_qc_report.pdf`: HiC QC report for reads mapped to an assembly.
+    - `*_qc_report.pdf`: HiC QC report for 5% of the HiC reads mapped to an assembly.
   - `*.hic`: The HiC contact map stored as a multi-resolution `.hic` file.
   - `*.assembly`: Assembly file created when the `hic_assembly_mode` is `true`
   - `*.bed`: The bed file listing the names of the contigs on the `assembly` super-scaffold when `hic_assembly_mode` is `true`

--- a/modules/local/samtools_subsample_sort.nf
+++ b/modules/local/samtools_subsample_sort.nf
@@ -1,0 +1,51 @@
+process SAMTOOLS_SUBSAMPLE_SORT {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samtools:1.21--h50ea8bc_0' :
+        'biocontainers/samtools:1.21--h50ea8bc_0' }"
+
+    input:
+    tuple val(meta), path(bam)
+    val(sample_fraction)  // Fraction of reads to sample (e.g., 0.05 for 5%)
+
+    output:
+    tuple val(meta), path("*.subsampled.sorted.bam"), emit: bam
+    path "versions.yml"                              , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def fraction = sample_fraction ?: 0.05
+    def seed = 42
+    // Convert fraction to integer percentage for -s flag (0.05 -> 5, 0.10 -> 10)
+    def fraction_int = (fraction * 100).toInteger()
+    
+    """
+    # Subsample reads and sort by name in one go
+    # Format for -s is SEED.FRACTION (e.g., 42.05 for 5% with seed 42)
+    samtools view -s ${seed}.${fraction_int} -b ${bam} \\
+        | samtools sort -n -@ ${task.cpus} ${args} -o ${prefix}.subsampled.sorted.bam -
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.subsampled.sorted.bam
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/local/samtools_subsample_sort.nf
+++ b/modules/local/samtools_subsample_sort.nf
@@ -1,6 +1,6 @@
 process SAMTOOLS_SUBSAMPLE_SORT {
     tag "$meta.id"
-    label 'process_low'
+    label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -22,14 +22,11 @@ process SAMTOOLS_SUBSAMPLE_SORT {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def fraction = sample_fraction ?: 0.05
-    def seed = 42
-    // Convert fraction to integer percentage for -s flag (0.05 -> 5, 0.10 -> 10)
-    def fraction_int = (fraction * 100).toInteger()
     
     """
     # Subsample reads and sort by name in one go
     # Format for -s is SEED.FRACTION (e.g., 42.05 for 5% with seed 42)
-    samtools view -s ${seed}.${fraction_int} -b ${bam} \\
+    samtools view -@ ${task.cpus} -s ${fraction} -b ${bam} \\
         | samtools sort -n -@ ${task.cpus} ${args} -o ${prefix}.subsampled.sorted.bam -
 
     cat <<-END_VERSIONS > versions.yml

--- a/subworkflows/gallvp/fastq_bwa_mem_samblaster/tests/nextflow.config
+++ b/subworkflows/gallvp/fastq_bwa_mem_samblaster/tests/nextflow.config
@@ -2,7 +2,7 @@ process {
     withName: BWA_MEM {
         ext.prefix = { "${meta.id}.on.${meta.ref_id}.bwa.mem" }
         ext.args = '-5SP'
-        ext.args2 = '-n'
+        // ext.args2 = '-n'
     }
 
     withName: SAMBLASTER {

--- a/subworkflows/local/fq2hic.nf
+++ b/subworkflows/local/fq2hic.nf
@@ -1,6 +1,7 @@
 include { FASTQ_FASTQC_UMITOOLS_FASTP   } from '../nf-core/fastq_fastqc_umitools_fastp/main'
 
 include { FASTQ_BWA_MEM_SAMBLASTER      } from '../gallvp/fastq_bwa_mem_samblaster/main'
+include { SAMTOOLS_SUBSAMPLE_SORT       } from '../../modules/local/samtools_subsample_sort.nf'
 include { HICQC                         } from '../../modules/gallvp/hicqc'
 
 include { FASTA_SEQKIT_REFSORT          } from '../gallvp/fasta_seqkit_refsort/main'
@@ -52,7 +53,7 @@ workflow FQ2HIC {
     ch_versions                     = ch_versions.mix(FASTA_SEQKIT_REFSORT.out.versions)
 
     // SUBWORKFLOW: FASTQ_BWA_MEM_SAMBLASTER
-    val_sort_bam = true
+    val_sort_bam = false
     FASTQ_BWA_MEM_SAMBLASTER(
         ch_trim_reads,
         ch_sorted_ref.map { meta2, fa -> [ meta2, fa, [] ] },
@@ -61,6 +62,15 @@ workflow FQ2HIC {
 
     ch_bam                          = FASTQ_BWA_MEM_SAMBLASTER.out.bam
     ch_versions                     = ch_versions.mix(FASTQ_BWA_MEM_SAMBLASTER.out.versions)
+
+    // MODULE: SAMTOOLS_SUBSAMPLE_SORT 
+    SAMTOOLS_SUBSAMPLE_SORT (
+        ch_bam,
+        0.05  // Sample 5% of reads 
+    )
+
+    ch_subsampled_sorted_bam        = SAMTOOLS_SUBSAMPLE_SORT.out.bam
+    ch_versions                     = ch_versions.mix(SAMTOOLS_SUBSAMPLE_SORT.out.versions)
 
     // MODULE: HICQC
     ch_bam_and_ref                  = ch_bam

--- a/subworkflows/local/fq2hic.nf
+++ b/subworkflows/local/fq2hic.nf
@@ -73,7 +73,7 @@ workflow FQ2HIC {
     ch_versions                     = ch_versions.mix(SAMTOOLS_SUBSAMPLE_SORT.out.versions)
 
     // MODULE: HICQC
-    ch_bam_and_ref                  = ch_bam
+    ch_bam_and_ref                  = ch_subsampled_sorted_bam
                                     | map { meta, bam -> [ meta.ref_id, meta, bam ] }
                                     | join(
                                         ch_sorted_ref.map { meta2, fa -> [ meta2.id, fa ] }


### PR DESCRIPTION
I spent some time trying to improve the runtime of the assemblyqc hic steps but my changes did not end up speeding up anything significantly so I think I will drop this. But I wanted to share since I did spend a few days on it and I learned a bit along the way. 
 
The pipeline was doing a `samtools sort -n` step during the hic.bam file creation. The name-sorted bam is only needed for the HICQC module, which only uses ~1M read pairs, so to speed things up I have turned off the name sorting and introduced a new module.
 
SAMTOOLS_SUBSAMPLE_SORT creates a new bam file of a subset of the hic.bam file that is 5% of the reads. This subset_hic.bam is then name-sorted and passed to HICQC.
The rest of the pipeline uses the full (not name-sorted) hic.bam
 
 
Unfortunately the time saved during the BWAMEM step does not pay off in the long run. Here is my test using the HYv4 dataset:



|            | Gallvp_Main_min | Iggy_fork_min | Gallvp_main_mem(GB) | Iggy_fork_mem(GB) |
|------------|-----------------|---------------|---------------|-----------------|
| BWA_MEM    | 349             | 281           | 17.7          | 5               |
| Samblaster | 121             | 110           | 5.63          | 5.63            |
| JuicerPre  | 66              | 108           |               |                 |
| SortSub    |                 | 29            |               | 7               |
|            |                 |               |               |                 |
| TOTAL TIME | 536             | 528           |               |                 |


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/plant-food-research-open/assemblyqc/tree/main/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes: `nextflow run . -profile test,docker --outdir <OUTDIR>` and `nf-test test --profile docker tests/`.
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
