### PR TITLE
Syri workflow update and Assemblathon memory allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 1. Updated nf-core pipeline template to 4.1.0
 2. Added sub workflow `fastq_minibwa_map_samblaster` and parameter `--hic_use_minibwa` set to `true` by default [#324](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/324)
+3. Changed SYRI workflow to use `.paf` files instead of `.bam` files [#333](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/333)
+4. Dynamic memory allocation for assemblathon based on genome size [#329](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/329)
 
 ### `Dependencies`
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -61,9 +61,9 @@ process {
     }
     withName: 'PLANTFOODRESEARCHOPEN_ASSEMBLYQC:ASSEMBLYQC:ASSEMBLATHON_STATS' {
         memory = {
-            def size    = fasta_file.size() as MemoryUnit
-            def mem_gb  = Math.min(150, Math.max(6, (8 + size.toGiga() * 10) as int))
-            mem_gb.GB + ((task.attempt - 1) * 8).GB
+            def perGBIncrement = ( fasta_file.size() as MemoryUnit ).toGiga() * 16
+            def attempt1MemGBs = Math.min(150, 8 + perGBIncrement)
+            ( attempt1MemGBs + (task.attempt - 1) * 8 ).GB
         }
     }
     withName:NCBI_FCS_GX_SCREEN_SAMPLES {

--- a/conf/base.config
+++ b/conf/base.config
@@ -59,6 +59,15 @@ process {
         errorStrategy = 'retry'
         maxRetries    = 2
     }
+    withName: 'PLANTFOODRESEARCHOPEN_ASSEMBLYQC:ASSEMBLYQC:ASSEMBLATHON_STATS' {
+        memory = {
+            def size_gb = fasta_file.size() / 1e9
+            def mem_gb  = Math.min(150, Math.max(6, (8 + size_gb * 10).round(0) as int))
+            "${mem_gb + ((task.attempt - 1) * 8)} GB"
+        }
+        errorStrategy = { task.exitStatus in [137,140] ? 'retry' : 'finish' }
+        maxRetries = 3
+    }
     withName:NCBI_FCS_GX_SCREEN_SAMPLES {
         time   = { 20.h  * task.attempt }
         memory = { 512.GB * task.attempt }

--- a/conf/base.config
+++ b/conf/base.config
@@ -61,12 +61,10 @@ process {
     }
     withName: 'PLANTFOODRESEARCHOPEN_ASSEMBLYQC:ASSEMBLYQC:ASSEMBLATHON_STATS' {
         memory = {
-            def size_gb = fasta_file.size() / 1e9
-            def mem_gb  = Math.min(150, Math.max(6, (8 + size_gb * 10).round(0) as int))
-            "${mem_gb + ((task.attempt - 1) * 8)} GB"
+            def size    = fasta_file.size() as MemoryUnit
+            def mem_gb  = Math.min(150, Math.max(6, (8 + size.toGiga() * 10) as int))
+            mem_gb.GB + ((task.attempt - 1) * 8).GB
         }
-        errorStrategy = { task.exitStatus in [137,140] ? 'retry' : 'finish' }
-        maxRetries = 3
     }
     withName:NCBI_FCS_GX_SCREEN_SAMPLES {
         time   = { 20.h  * task.attempt }

--- a/subworkflows/local/fasta_synteny.nf
+++ b/subworkflows/local/fasta_synteny.nf
@@ -302,23 +302,23 @@ workflow FASTA_SYNTENY {
     MINIMAP2_ALIGN(
         ch_minimap_inputs.map { meta, tfa, _rfa -> [ meta, tfa ] },
         ch_minimap_inputs.map { meta, _tfa, rfa -> [ meta, rfa ] },
-        true,   // bam_format
+        false,   // bam_format
         'bai',  // bam_index_extension
-        false,  // cigar_paf_format
+        true,  // cigar_paf_format
         false   // cigar_bam
     )
 
-    ch_minimap2_bam                     = MINIMAP2_ALIGN.out.bam
+    ch_minimap2_paf                     = MINIMAP2_ALIGN.out.paf
 
     // MODULE: SYRI
-    ch_syri_inputs                      = ch_minimap2_bam
+    ch_syri_inputs                      = ch_minimap2_paf
                                         | join(ch_minimap_inputs)
 
     SYRI(
-        ch_syri_inputs.map { meta, bam, _tfa, _rfa -> [ meta, bam ] },
+        ch_syri_inputs.map { meta, paf, _tfa, _rfa -> [ meta, paf ] },
         ch_syri_inputs.map { _meta, _bam, tfa, _rfa -> tfa },
         ch_syri_inputs.map { _meta, _bam, _tfa, rfa -> rfa },
-        'B' // BAM
+        'P' // PAF
     )
 
     ch_syri                             = SYRI.out.syri


### PR DESCRIPTION
Dynamic memory allocation for assemblathon based on genome size: [Assemblathon module OOM for large genomes · #329 


Changing the workflow:
FROM: minimap2 -> samtools sort -> BAM -> SYRI
TO: minimap2 -> PAF -> SYRI
#333 


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/plant-food-research-open/assemblyqc/tree/main/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes: `nextflow run . -profile test,docker --outdir <OUTDIR>` and `nf-test test --profile docker tests/`.
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
