### PR TITLE
[GH-318] --hic_map_combinations does not allow self-referential combinationsnations anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v3.1.0dev - [10-Aug-2026]
+## v3.1.0dev - [11-Aug-2026]
 
 ### `Added`
 
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 1. Fixed an issue where `--hic_map_combinations` parameter set to "" was not being interpreted as `null` and resulted in no HiC maps being generated [#321](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/321)
+2. Fixed an issue where `--hic_map_combinations` parameter was not being validated correctly and allowed self-referential combinations to be specified [#318](https://github.com/Plant-Food-Research-Open/assemblyqc/issues/318)
 
 ### `Dependencies`
 

--- a/subworkflows/local/utils_nfcore_assemblyqc_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_assemblyqc_pipeline/main.nf
@@ -345,7 +345,7 @@ def validateInputTags(List<String> assemblyTags, String hicCombinations) {
         error("Please check input assemblysheet -> Multiple assemblies have the same tags!: ${repeatedTags}")
     }
 
-    def hicTags = hicCombinations != null ? hicCombinations.tokenize(' ').collect { it.tokenize(':') }.flatten() : []
+    def hicTags = hicCombinations != null ? hicCombinations.tokenize(' ').collect { combination -> combination.tokenize(':') }.flatten() : []
 
     hicTags.each { hicTag ->
         if ( hicTag !in assemblyTags ) {
@@ -353,8 +353,12 @@ def validateInputTags(List<String> assemblyTags, String hicCombinations) {
         }
     }
 
+    if ( hicCombinations == null || hicCombinations == "" ) {
+        return true
+    }
+
     // Make sure that all hic combinations are unique
-    def hicCombinationsUnique = hicCombinations != null ? hicCombinations.tokenize(' ').unique() : []
+    def hicCombinationsUnique = hicCombinations.tokenize(' ').unique()
     if ( hicCombinationsUnique.size() != hicCombinations.tokenize(' ').size() ) {
         error("Please check input hic_map_combinations -> Some combinations are repeated!")
     }

--- a/subworkflows/local/utils_nfcore_assemblyqc_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_assemblyqc_pipeline/main.nf
@@ -333,7 +333,7 @@ def validateInputParameters() {
     }
 }
 
-def validateInputTags(assemblyTags, hicCombinations) {
+def validateInputTags(List<String> assemblyTags, String hicCombinations) {
 
     def tagCounts = [:]
     assemblyTags.each { tag ->
@@ -347,9 +347,23 @@ def validateInputTags(assemblyTags, hicCombinations) {
 
     def hicTags = hicCombinations != null ? hicCombinations.tokenize(' ').collect { it.tokenize(':') }.flatten() : []
 
-    hicTags.each {
-        if ( it !in assemblyTags ) {
-            error("Please check input hic_map_combinations -> $it was not found in the assemblysheet!")
+    hicTags.each { hicTag ->
+        if ( hicTag !in assemblyTags ) {
+            error("Please check input hic_map_combinations -> $hicTag was not found in the assemblysheet!")
+        }
+    }
+
+    // Make sure that all hic combinations are unique
+    def hicCombinationsUnique = hicCombinations != null ? hicCombinations.tokenize(' ').unique() : []
+    if ( hicCombinationsUnique.size() != hicCombinations.tokenize(' ').size() ) {
+        error("Please check input hic_map_combinations -> Some combinations are repeated!")
+    }
+
+    // Make sure that no hic combination is self-referential
+    hicCombinationsUnique.each { hicCombination ->
+        def hicCombinationTags = hicCombination.tokenize(':')
+        if ( hicCombinationTags.size() != hicCombinationTags.unique().size() ) {
+            error("Please check input hic_map_combinations -> ${hicCombination} combination is self-referential!")
         }
     }
 

--- a/tests/hic/hictags.nf.test
+++ b/tests/hic/hictags.nf.test
@@ -1,0 +1,70 @@
+nextflow_function {
+
+    name "checkHiCParam"
+    script "../../subworkflows/local/utils_nfcore_assemblyqc_pipeline/main.nf"
+    function "validateInputTags"
+
+    test("HY -- HY -- pass") {
+        when {
+            function {
+                """
+                input[0] = [ "HY" ]
+                input[1] = "HY"
+                """
+            }
+        }
+
+        then {
+            assert function.success
+            assert function.result
+        }
+    }
+
+    test("HY1 HY2 -- HY1 HY1:HY2 -- pass") {
+        when {
+            function {
+                """
+                input[0] = [ "HY1", "HY2" ]
+                input[1] = "HY1 HY1:HY2"
+                """
+            }
+        }
+
+        then {
+            assert function.success
+            assert function.result
+        }
+    }
+
+    test("HY -- HY HY -- fail") {
+        when {
+            function {
+                """
+                input[0] = [ "HY" ]
+                input[1] = "HY HY"
+                """
+            }
+        }
+
+        then {
+            assert ! function.success
+            assert 'Please check input hic_map_combinations -> Some combinations are repeated!' in function.stdout
+        }
+    }
+
+    test("HY -- HY:HY -- fail") {
+        when {
+            function {
+                """
+                input[0] = [ "HY" ]
+                input[1] = "HY:HY"
+                """
+            }
+        }
+
+        then {
+            assert ! function.success
+            assert 'Please check input hic_map_combinations -> HY:HY combination is self-referential!' in function.stdout
+        }
+    }
+}


### PR DESCRIPTION


<!--
# plant-food-research-open/assemblyqc pull request

Many thanks for contributing to plant-food-research-open/assemblyqc!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/plant-food-research-open/assemblyqc/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/plant-food-research-open/assemblyqc/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes: `nextflow run . -profile test,docker --outdir <OUTDIR>` and `nf-test test --profile docker tests/`.
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
